### PR TITLE
Fix symlink

### DIFF
--- a/asset_cache_test_child/tmp/cache/sprockets-4.0
+++ b/asset_cache_test_child/tmp/cache/sprockets-4.0
@@ -1,1 +1,1 @@
-asset_cache_test_parent/tmp/cache/sprockets-4.0/
+../../../asset_cache_test_parent/tmp/cache/sprockets-4.0/


### PR DESCRIPTION
First one wasn't correct.

```
$ ls asset_cache_test_child/tmp/cache/sprockets-4.0
37D 3D7 400 436 442 464 477 484 490 4A1 4B3 4BA 4C2 4E2 4F4 50C 51C 550 58C
39B 3EA 413 43A 449 470 47D 485 493 4A2 4B4 4BB 4CA 4E8 4F5 511 528 55A 596
3A2 3F3 42F 43E 44A 472 480 488 496 4A6 4B5 4BF 4D2 4EA 500 512 52E 575 5B8
3D4 3FC 432 441 457 474 483 48C 49F 4AB 4B7 4C0 4DF 4F2 503 517 548 582 5FF
$ ls -la asset_cache_test_child/tmp/cache/sprockets-4.0
lrwxr-xr-x  1 richardschneeman  staff  57 Sep 24 14:47 asset_cache_test_child/tmp/cache/sprockets-4.0 -> ../../../asset_cache_test_parent/tmp/cache/sprockets-4.0/
```

Apparently it wasn't relative and ended up making a file instead of a directory.
